### PR TITLE
Add support for disabled state and toggle button

### DIFF
--- a/SKSpriteButton/Classes/SKSpriteButton.swift
+++ b/SKSpriteButton/Classes/SKSpriteButton.swift
@@ -50,7 +50,17 @@ public class SKSpriteButton: SKSpriteNode {
     // Button becomes a toggle switch that switches between normal and tapped
     public var toggleMode: Bool = false
     
-    public var isToggledOn: Bool = false
+    public var isToggledOn: Bool = false {
+        didSet {
+            // Don't call handlers as this is not an action when set manually
+            // this is necessary when having a group of buttons to toggle each other
+            if isToggledOn {
+                showTappedAppearance()
+            } else {
+                showNormalAppearance()
+            }
+        }
+    }
     
     /// Used to prevent touch recognition
     /// Will show the disabled texture and disabled color

--- a/SKSpriteButton/Classes/SKSpriteButton.swift
+++ b/SKSpriteButton/Classes/SKSpriteButton.swift
@@ -48,7 +48,16 @@ public class SKSpriteButton: SKSpriteNode {
     }
     
     // Button becomes a toggle switch that switches between normal and tapped
-    public var toggleMode: Bool = false
+    public var isToggleMode: Bool = false {
+        didSet {
+            // Run again in case isToggleOn set first
+            if isToggledOn {
+                showTappedAppearance()
+            } else {
+                showNormalAppearance()
+            }
+        }
+    }
     
     public var isToggledOn: Bool = false {
         didSet {
@@ -290,7 +299,11 @@ private extension SKSpriteButton {
             return
         }
         
-        invokeTouchesUpBehavior(touches, event)
+        if isToggleMode {
+            invokeToggleBehavior(touches, event)
+        } else {
+            invokeTouchesUpBehavior(touches, event)
+        }
     }
     
     func touchesCancelled(_ touches: Set<UITouch>, _ event: UIEvent?) {
@@ -369,37 +382,7 @@ private extension SKSpriteButton {
     }
     
     func invokeTouchesUpBehavior(_ touches: Set<UITouch>, _ event: UIEvent?) {
-        if toggleMode {
-            if isToggledOn {
-                // Group toogle cannot self toggle off
-                if toggleGroup.count > 0 {
-                    return
-                }
-                
-                triggerToggledOff()
-                
-                toggleOffHandlers.forEach {
-                    handler in
-                    handler(touches, event)
-                }
-                
-            } else {
-                triggerToggledOn()
-                
-                for button in toggleGroup {
-                    button.isToggledOn = false
-                }
-                
-                toggleOnHandlers.forEach {
-                    handler in
-                    handler(touches, event)
-                }
-                
-            }
-        } else {
-            triggerNormal()
-        }
-        
+        triggerNormal()
         touchesUpHandlers.forEach {
             handler in
             handler(touches, event)
@@ -419,6 +402,40 @@ private extension SKSpriteButton {
             handler in
             handler(touches, event)
         }
+    }
+    
+    func invokeToggleBehavior(_ touches: Set<UITouch>, _ event: UIEvent?) {
+        if isToggledOn {
+            // Group toogle cannot self toggle off
+            if toggleGroup.count > 0 {
+                return
+            }
+            
+            triggerToggledOff()
+            
+            toggleOffHandlers.forEach {
+                handler in
+                handler(touches, event)
+            }
+            
+        } else {
+            triggerToggledOn()
+            
+            for button in toggleGroup {
+                button.isToggledOn = false
+            }
+            
+            toggleOnHandlers.forEach {
+                handler in
+                handler(touches, event)
+            }
+        }
+        
+        touchesUpHandlers.forEach {
+            handler in
+            handler(touches, event)
+        }
+        
     }
     
     func triggerNormal() {
@@ -453,5 +470,6 @@ private extension SKSpriteButton {
         }
         return true
     }
+    
 }
 

--- a/SKSpriteButton/Classes/SKSpriteButton.swift
+++ b/SKSpriteButton/Classes/SKSpriteButton.swift
@@ -55,20 +55,21 @@ public class SKSpriteButton: SKSpriteNode {
     /// Used to prevent touch recognition
     /// Will show the disabled texture and disabled color
     public var disabled: Bool = false {
-        willSet {
+        didSet {
             isUserInteractionEnabled = !disabled
             if disabled {
                 showDisabledAppearance()
             } else {
                 showNormalAppearance()
             }
+            
         }
     }
     
     /// The `SKSpriteButton.MoveType` of this button.
     /// Default to `.alwaysHeld`.
     public var moveType: MoveType = .alwaysHeld {
-        willSet {
+        didSet {
             isUserInteractionEnabled = !disabled
         }
     }
@@ -95,10 +96,8 @@ public class SKSpriteButton: SKSpriteNode {
     /// Set this variable if you want to display a
     /// different texture when the button is tapped.
     public var tappedTexture: SKTexture? {
-        willSet {
-            isUserInteractionEnabled = !disabled
-        }
         didSet {
+            isUserInteractionEnabled = !disabled
             // more than one texture is associated with node so keep of copy of the normal texture
             if storedNormalTexture == nil {
                 storedNormalTexture = texture
@@ -108,10 +107,8 @@ public class SKSpriteButton: SKSpriteNode {
     
     /// Color to display when a button is tapped.
     public var tappedColor: UIColor? {
-        willSet {
-            isUserInteractionEnabled = !disabled
-        }
         didSet {
+            isUserInteractionEnabled = !disabled
             // more than one color is associated with node so keep of copy of the normal color
             if storedNormalColor == nil {
                 storedNormalColor = color
@@ -122,10 +119,8 @@ public class SKSpriteButton: SKSpriteNode {
     /// Set this variable if you want to display a
     /// different texture when the button is disabled.
     public var disabledTexture: SKTexture? {
-        willSet {
-            isUserInteractionEnabled = !disabled
-        }
         didSet {
+            isUserInteractionEnabled = !disabled
             if storedNormalTexture == nil {
                 storedNormalTexture = texture
             }
@@ -137,10 +132,8 @@ public class SKSpriteButton: SKSpriteNode {
     
     /// Color to display when a button is disabled.
     public var disabledColor: UIColor? {
-        willSet {
-            isUserInteractionEnabled = !disabled
-        }
         didSet {
+            isUserInteractionEnabled = !disabled
             if storedNormalColor == nil {
                 storedNormalColor = color
             }
@@ -425,5 +418,4 @@ private extension SKSpriteButton {
         return true
     }
 }
-
 


### PR DESCRIPTION
Disabled state is represented by property "disabled" and will render assigned texture and color as well as disable touch events.

Toggle state is defined by  boolean "isToggledOn" and is enabled by the boolean property "toggleMode". This property will switch between the normal color/texture and the tapped color/texture  states with each "touch up" of the button. It will also fire separate handlers for each (toggleOnHandlers and toggleOffHandlers).

This should maintain backwards compatibility and should pass E2E tests but I am expecting it to break unit tests. Sorry for that!